### PR TITLE
Add a retry with system ca bundle if oauth ssl error occurs

### DIFF
--- a/oauthenticator/openshift.py
+++ b/oauthenticator/openshift.py
@@ -13,6 +13,7 @@ import requests
 from jupyterhub.auth import LocalAuthenticator
 from tornado import web
 from tornado.auth import OAuth2Mixin
+from tornado.curl_httpclient import CurlError
 from tornado.httpclient import AsyncHTTPClient, HTTPClient, HTTPRequest
 from tornado.httputil import url_concat
 
@@ -43,6 +44,8 @@ class OpenShiftOAuthenticator(OAuthenticator):
     )
 
     ca_certs = Unicode(config=True)
+    system_ca_certs = Unicode(config=True)
+    use_ca_certs_for_token_request = True if ca_certs else False
 
     allowed_groups = Set(
         config=True,
@@ -59,7 +62,13 @@ class OpenShiftOAuthenticator(OAuthenticator):
         ca_cert_file = "/run/secrets/kubernetes.io/serviceaccount/ca.crt"
         if self.validate_cert and os.path.exists(ca_cert_file):
             return ca_cert_file
+        return ''
 
+    @default("system_ca_certs")
+    def _system_ca_certs_default(self):
+        ca_cert_file = "/etc/pki/tls/cert.pem"
+        if self.validate_cert and os.path.exists(ca_cert_file):
+            return ca_cert_file
         return ''
 
     openshift_auth_api_url = Unicode(config=True)
@@ -118,16 +127,24 @@ class OpenShiftOAuthenticator(OAuthenticator):
 
         url = url_concat(self.token_url, params)
 
-        req = HTTPRequest(
-            url,
-            method="POST",
-            validate_cert=self.validate_cert,
-            ca_certs=self.ca_certs,
-            headers={"Accept": "application/json"},
-            body='',  # Body is required for a POST...
-        )
-
-        resp = await http_client.fetch(req)
+        def token_request(url):
+            return HTTPRequest(
+                url,
+                method="POST",
+                validate_cert=self.validate_cert,
+                ca_certs=self.ca_certs if self.use_ca_certs_for_token_request else self.system_ca_certs,
+                headers={"Accept": "application/json"},
+                body='',  # Body is required for a POST...
+               )
+        try:
+            req = token_request(url)
+            resp = await http_client.fetch(req)
+        except CurlError:
+            certs = "system ca certs" if self.use_ca_certs_for_token_request else "ca certs"
+            self.log.info("Retrying oauth token request with %s" % certs)
+            self.use_ca_certs_for_token_request = not self.use_ca_certs_for_token_request
+            req = token_request(url)
+            resp = await http_client.fetch(req)
 
         resp_json = json.loads(resp.body.decode('utf8', 'replace'))
 


### PR DESCRIPTION
In some clusters, the OpenShift oauth endpoint will not be
self-signed like the api endpoint. In this case, retry calls
to the oauth endpoint with the default system ca bundle.