### PR TITLE
Revert "Changed httponly property of cookie to False"

### DIFF
--- a/oauthenticator/oauth2.py
+++ b/oauthenticator/oauth2.py
@@ -73,7 +73,7 @@ class OAuthLoginHandler(OAuth2Mixin, BaseHandler):
         return self.authenticator.userdata_url
 
     def set_state_cookie(self, state):
-        self._set_cookie(STATE_COOKIE_NAME, state, expires_days=1, httponly=False)
+        self._set_cookie(STATE_COOKIE_NAME, state, expires_days=1, httponly=True)
 
     _state = None
 


### PR DESCRIPTION
Reverts opendatahub-io/oauthenticator#1

Setting httponly=False allows or cross-site script attacs, reverting this change